### PR TITLE
ENG-47876 : closed IO streams in finally block

### DIFF
--- a/pom.xml.versionsBackup
+++ b/pom.xml.versionsBackup
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>4.83</version>
     <relativePath />
   </parent>
   <groupId>io.jenkins.plugins</groupId>

--- a/src/main/java/io/jenkins/plugins/traceable/ast/TraceableASTGenerateReportAction.java
+++ b/src/main/java/io/jenkins/plugins/traceable/ast/TraceableASTGenerateReportAction.java
@@ -77,7 +77,7 @@ public class TraceableASTGenerateReportAction implements RunAction2 {
                     .append(tempFile.getAbsolutePath())
                     .toString();
             for (int i = 0; i < args.length; i++) {
-                if (args[i] != null && !args[i].equals("")) execScript += " " + args[i];
+                if (args[i] != null && !args[i].isEmpty()) execScript += " " + args[i];
                 else execScript += " ''";
             }
             ProcessBuilder processBuilder = new ProcessBuilder(execScript);
@@ -172,26 +172,43 @@ public class TraceableASTGenerateReportAction implements RunAction2 {
         return "";
     }
 
-    private String readFile(Path filePath) {
+    private String readFile(Path filePath) throws IOException {
+        InputStream is = null;
+        InputStreamReader isr = null;
+        BufferedReader br = null;
+
         try {
-            InputStream is = java.nio.file.Files.newInputStream(filePath);
-            InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
-            BufferedReader br = new BufferedReader(isr);
+            is = java.nio.file.Files.newInputStream(filePath);
+            isr = new InputStreamReader(is, StandardCharsets.UTF_8);
+            br = new BufferedReader(isr);
             return br.lines().collect(Collectors.joining("\n"));
         } catch (IOException e) {
             e.printStackTrace();
+        } finally {
+            if (is != null) {
+                is.close();
+            }
+            if (isr != null) {
+                isr.close();
+            }
+            if (br != null) {
+                br.close();
+            }
         }
         return "";
     }
 
-    private void writeToFile(File file, String data) {
+    private void writeToFile(File file, String data) throws IOException {
         FileWriter fw = null;
         try {
             fw = new FileWriter(file, true);
             fw.append(data);
-            fw.close();
         } catch (IOException e) {
             e.printStackTrace();
+        } finally {
+            if (fw != null) {
+                fw.close();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary:
- Closed IO streams using a finally block.
- Replaced `.equals("")` with `.isEmpty()`