### PR TITLE
Jenkins review fix 

### DIFF
--- a/src/main/java/io/jenkins/plugins/traceable/ast/TraceableASTGenerateReportAction.java
+++ b/src/main/java/io/jenkins/plugins/traceable/ast/TraceableASTGenerateReportAction.java
@@ -19,6 +19,7 @@ public class TraceableASTGenerateReportAction implements RunAction2 {
     private Secret clientToken;
     private String traceableRootCaFileName;
     private String traceableCliCertFileName;
+    // lgtm[jenkins/plaintext-storage]
     private String traceableCliKeyFileName;
     private final FilePath workspace;
     private final TaskListener listener;

--- a/src/main/java/io/jenkins/plugins/traceable/ast/TraceableApiInspectorStepBuilder.java
+++ b/src/main/java/io/jenkins/plugins/traceable/ast/TraceableApiInspectorStepBuilder.java
@@ -9,6 +9,7 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
+import hudson.util.Secret;
 import io.jenkins.plugins.traceable.ast.scan.utils.ApiInspector;
 import java.io.IOException;
 import jenkins.tasks.SimpleBuildStep;
@@ -23,7 +24,7 @@ public class TraceableApiInspectorStepBuilder extends Builder implements SimpleB
     private String repoPath;
     private String specFilePath;
     private String traceableServer;
-    private String traceableToken;
+    private static Secret traceableToken;
     private StringBuilder report;
 
     public String getRepoPath() {
@@ -38,7 +39,7 @@ public class TraceableApiInspectorStepBuilder extends Builder implements SimpleB
         return traceableServer;
     }
 
-    public String getTraceableToken() {
+    public static Secret getTraceableToken() {
         return traceableToken;
     }
 
@@ -58,8 +59,8 @@ public class TraceableApiInspectorStepBuilder extends Builder implements SimpleB
     }
 
     @DataBoundSetter
-    public void setTraceableToken(String traceableToken) {
-        this.traceableToken = traceableToken;
+    public static void setTraceableToken(Secret traceableToken) {
+        TraceableApiInspectorStepBuilder.traceableToken = traceableToken;
     }
 
     @DataBoundConstructor
@@ -79,7 +80,8 @@ public class TraceableApiInspectorStepBuilder extends Builder implements SimpleB
         if (StringUtils.isBlank(specFilePath)) {
             findAndInspect(workspace, listener, repoWorkspacePath, scriptPath);
         } else {
-            String[] args = new String[] {traceableServer, traceableToken, specFilePath};
+            String absoluteSpecFilePath = repoWorkspacePath + "/" + specFilePath;
+            String[] args = new String[] {traceableServer, traceableToken.getPlainText(), absoluteSpecFilePath};
             report.append(runScript(workspace, listener, scriptPath, args, true));
         }
 
@@ -101,7 +103,7 @@ public class TraceableApiInspectorStepBuilder extends Builder implements SimpleB
         }
 
         for (String specFile : specFilePathsList) {
-            String[] args = new String[] {traceableServer, traceableToken, specFile};
+            String[] args = new String[] {traceableServer, traceableToken.getPlainText(), specFile};
             String newOpenApiSpecString =
                     "========================================\nUploading open api spec : " + specFile + "\n";
             listener.getLogger().println(newOpenApiSpecString);

--- a/src/main/java/io/jenkins/plugins/traceable/ast/scan/utils/ApiInspector.java
+++ b/src/main/java/io/jenkins/plugins/traceable/ast/scan/utils/ApiInspector.java
@@ -2,7 +2,6 @@ package io.jenkins.plugins.traceable.ast.scan.utils;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
-import hudson.FilePath.FileCallable;
 import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
 import java.io.BufferedWriter;
@@ -17,9 +16,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Scanner;
 import java.util.UUID;
-import org.jenkinsci.remoting.RoleChecker;
+import jenkins.MasterToSlaveFileCallable;
 
-public class ApiInspector implements FileCallable<String> {
+public class ApiInspector extends MasterToSlaveFileCallable<String> {
 
     private final TaskListener listener;
     private final String scriptPath;
@@ -44,11 +43,6 @@ public class ApiInspector implements FileCallable<String> {
         deleteScript();
 
         return returnOutput.toString();
-    }
-
-    @Override
-    public void checkRoles(RoleChecker checker) throws SecurityException {
-        return;
     }
 
     private void copyScript() throws IOException {

--- a/src/main/java/io/jenkins/plugins/traceable/ast/scan/utils/DownloadTraceableCliBinary.java
+++ b/src/main/java/io/jenkins/plugins/traceable/ast/scan/utils/DownloadTraceableCliBinary.java
@@ -1,6 +1,5 @@
 package io.jenkins.plugins.traceable.ast.scan.utils;
 
-import hudson.FilePath.FileCallable;
 import hudson.remoting.VirtualChannel;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
@@ -10,9 +9,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
-import org.jenkinsci.remoting.RoleChecker;
+import jenkins.MasterToSlaveFileCallable;
 
-public class DownloadTraceableCliBinary implements FileCallable<Void> {
+public class DownloadTraceableCliBinary extends MasterToSlaveFileCallable<Void> {
 
     private String workspacePath;
     private String version;
@@ -48,12 +47,6 @@ public class DownloadTraceableCliBinary implements FileCallable<Void> {
         unTar(filepath);
 
         return null;
-    }
-
-    @Override
-    public void checkRoles(RoleChecker checker) throws SecurityException {
-        // We want this to be able to run on any type of machine (controller or agent)
-        return;
     }
 
     private String getKernelName() throws IOException, InterruptedException {

--- a/src/main/java/io/jenkins/plugins/traceable/ast/scan/utils/GenerateReport.java
+++ b/src/main/java/io/jenkins/plugins/traceable/ast/scan/utils/GenerateReport.java
@@ -2,7 +2,6 @@ package io.jenkins.plugins.traceable.ast.scan.utils;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
-import hudson.FilePath.FileCallable;
 import hudson.remoting.VirtualChannel;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -17,9 +16,9 @@ import java.util.Scanner;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.jenkinsci.remoting.RoleChecker;
+import jenkins.MasterToSlaveFileCallable;
 
-public class GenerateReport implements FileCallable<String[]> {
+public class GenerateReport extends MasterToSlaveFileCallable<String[]> {
 
     private final String scriptPath;
     private String[] args;
@@ -45,11 +44,6 @@ public class GenerateReport implements FileCallable<String[]> {
 
         String[] ret = {this.processExitValue, this.htmlReport};
         return ret;
-    }
-
-    @Override
-    public void checkRoles(RoleChecker checker) throws SecurityException {
-        return;
     }
 
     private void copyScript() throws IOException {

--- a/src/main/java/io/jenkins/plugins/traceable/ast/scan/utils/RunScript.java
+++ b/src/main/java/io/jenkins/plugins/traceable/ast/scan/utils/RunScript.java
@@ -2,7 +2,6 @@ package io.jenkins.plugins.traceable.ast.scan.utils;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
-import hudson.FilePath.FileCallable;
 import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
 import java.io.BufferedWriter;
@@ -17,10 +16,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Scanner;
 import java.util.UUID;
+import jenkins.MasterToSlaveFileCallable;
 import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.remoting.RoleChecker;
 
-public class RunScript implements FileCallable<String> {
+public class RunScript extends MasterToSlaveFileCallable<String> {
 
     private final TaskListener listener;
     private final String scriptPath;
@@ -44,12 +43,6 @@ public class RunScript implements FileCallable<String> {
         runScript();
         deleteScript();
         return RunScript.scanId;
-    }
-
-    @Override
-    public void checkRoles(RoleChecker checker) throws SecurityException {
-        // We want this to be able to run on any type of machine (controller or agent)
-        return;
     }
 
     private void copyScript() throws IOException {


### PR DESCRIPTION
## Summary:
Issues Link: https://github.com/jenkins-infra/repository-permissions-updater/issues/3977#issuecomment-2286585867

## Fixes:
- Replaced `implements FileCallable` with `extends MasterToSlaveFileCallable`. This places a role-check to make sure the Callable can only be called by the controller.
- Replaced `String` with `Secret` for traceableToken in `ApiInspectorStepBuilder`.
- Added suppress warnings for `traceableCliKeyFileName`.
- Appended `repoWorkspacePath` before `specFilePath` if user provides the `specFilePath`.