### PR TITLE
Review-fix-2: Appended traceable to build step names

### DIFF
--- a/src/main/java/io/jenkins/plugins/traceable/ast/TraceableASTInitAndRunStepBuilder.java
+++ b/src/main/java/io/jenkins/plugins/traceable/ast/TraceableASTInitAndRunStepBuilder.java
@@ -483,7 +483,7 @@ public class TraceableASTInitAndRunStepBuilder extends Builder implements Simple
     }
 
     @Extension
-    @Symbol("scanInitAndRun")
+    @Symbol("traceableScanInitAndRun")
     public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
 
         private final String STEP_NAME = "Traceable AST - Initialize and Run";

--- a/src/main/java/io/jenkins/plugins/traceable/ast/TraceableASTInitStepBuilder.java
+++ b/src/main/java/io/jenkins/plugins/traceable/ast/TraceableASTInitStepBuilder.java
@@ -425,7 +425,7 @@ public class TraceableASTInitStepBuilder extends Builder implements SimpleBuildS
     }
 
     @Extension
-    @Symbol("scanInit")
+    @Symbol("traceableScanInit")
     public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
 
         private final String STEP_NAME = "Traceable AST - Initialize";

--- a/src/main/java/io/jenkins/plugins/traceable/ast/TraceableASTResultStepBuilder.java
+++ b/src/main/java/io/jenkins/plugins/traceable/ast/TraceableASTResultStepBuilder.java
@@ -70,7 +70,7 @@ public class TraceableASTResultStepBuilder extends Builder implements SimpleBuil
     }
 
     @Extension
-    @Symbol("scanResult")
+    @Symbol("traceableScanResult")
     public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
 
         private final String STEP_NAME = "Traceable AST - Generate Scan Result";

--- a/src/main/java/io/jenkins/plugins/traceable/ast/TraceableASTRunStepBuilder.java
+++ b/src/main/java/io/jenkins/plugins/traceable/ast/TraceableASTRunStepBuilder.java
@@ -97,7 +97,7 @@ public class TraceableASTRunStepBuilder extends Builder implements SimpleBuildSt
     }
 
     @Extension
-    @Symbol("scanRun")
+    @Symbol("traceableScanRun")
     public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
 
         private final String STEP_NAME = "Traceable AST - Run";

--- a/src/main/java/io/jenkins/plugins/traceable/ast/TraceableApiInspectorStepBuilder.java
+++ b/src/main/java/io/jenkins/plugins/traceable/ast/TraceableApiInspectorStepBuilder.java
@@ -125,7 +125,7 @@ public class TraceableApiInspectorStepBuilder extends Builder implements SimpleB
     }
 
     @Extension
-    @Symbol("apiInspectorRun")
+    @Symbol("traceableApiInspectorRun")
     public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
 
         private final String STEP_NAME = "Traceable API Inspector";


### PR DESCRIPTION
## Summary:
- Prepended `traceable` to the existing step names